### PR TITLE
Some references

### DIFF
--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -37,8 +37,10 @@ normative:
   RFC2119:
   
 informative:
+  I-D.ietf-tcpm-converters:
   I-D.deconinck-quic-multipath:
   I-D.amend-tsvwg-multipath-dccp:
+  I-D.boucadair-mptcp-plain-mode:
   TS23501:
     author:
       - ins: 3GPP (3rd Generation Partnership Project)


### PR DESCRIPTION
* 0-RTT Converter
* draft-boucadair-mptcp-plain-mode-08#section-5: defined how any protocol (including UDP) can be encapsulated in MPTCP but that approach requires some "relax" of TCP features. That design was abandoned hence the need for solutions that would provide a functional parity as Convert Protocol.