### PR TITLE
Need to call out the security considerations

### DIFF
--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -621,7 +621,7 @@ This document makes no requests of IANA.
 
 # Security Considerations
 
-This document is informational in nature, providing a translation of a 3GPP specification for IETF readers who are not familiar with ATSSS or 5G. It has no effect on the security of ATSSS or 5G networks. 
+This section will be completed. 
 
 # Acknowledgements
 


### PR DESCRIPTION
The document includes some proposals that are not reflecting 3GPP Specs (e.g., ATSSSv2 section). We will need to complete the security considerations section once we have that section stable.