### PR TITLE
Reflect the content of the document in the abstract

### DIFF
--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -140,6 +140,8 @@ informative:
 
 This document briefly presents the Access Traffic Steering, Switching, and Splitting (ATSSS) service being specified within the 3rd Generation Partnership Project (3GPP). 
 
+The document also assesses to what extent IETF specifications can be used to meet the ATSSS design goals; gaps (if any) will be documented.  
+
 --- middle
 
 # Introduction {#intro}


### PR DESCRIPTION
ATSSSv2 cannot be considered as part of the "ATSSS overview". We need to adequately reflect this in the abstract (title as well).