### PR TITLE
Atsss rules

### DIFF
--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -237,7 +237,7 @@ the different access networks even if the server does not support it (i.e., is n
 at transport layer).
 
 The 5G control plane provides the UE and the Proxy with rules that specify
-which flows are eligible to the ATSSS service (i.e. by mapping them to a Multi-Access PDU Session). Additionally, a set of ATSSS rules are delivered to the UE and the Proxy that control the treatment of each of these flows within this MA-PDU Session.
+which flows are eligible to the ATSSS service (i.e. by mapping them to a Multi-Access PDU Session). Once a Multi-Access PDU Session has been established, a set of ATSSS rules are then delivered to both the UE and the Proxy in order to control the treatment of the flows within the Session.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -237,7 +237,7 @@ the different access networks even if the server does not support it (i.e., is n
 at transport layer).
 
 The 5G control plane provides the UE and the Proxy with rules that specify
-which flows are eligible to the ATSSS service.
+which flows are eligible to the ATSSS service. Additionally, a set of ATSSS rules are delivered to the UE and the Proxy that control how each flow is treated within the ATSSS service.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -237,7 +237,7 @@ the different access networks even if the server does not support it (i.e., is n
 at transport layer).
 
 The 5G control plane provides the UE and the Proxy with rules that specify
-which flows are eligible to the ATSSS service. Additionally, a set of ATSSS rules are delivered to the UE and the Proxy that control how each flow is treated within the ATSSS service.
+which flows are eligible to the ATSSS service (i.e. by mapping them to a Multi-Access PDU Session). Additionally, a set of ATSSS rules are delivered to the UE and the Proxy that control the treatment of each of these flows within this MA-PDU Session.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 

--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -237,7 +237,7 @@ the different access networks even if the server does not support it (i.e., is n
 at transport layer).
 
 The 5G control plane provides the UE and the Proxy with rules that specify
-which flows are eligible to the ATSSS service (i.e. by mapping them to a Multi-Access PDU Session). Once a Multi-Access PDU Session has been established, a set of ATSSS rules are then delivered to both the UE and the Proxy in order to control the treatment of the flows within the Session.
+which flows are eligible to the ATSSS service (i.e. by mapping them to a Multi-Access PDU Session). Once a Multi-Access PDU Session has been established, a set of ATSSS rules are then delivered to both the UE and the Proxy in order to enable unified treatment of the flows by both the UE and the Proxy within the Session.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
@@ -632,4 +632,3 @@ This document is informational in nature, providing a translation of a 3GPP spec
 (Note to RFC Editor - if this document ever reaches you, please remove this section)
 
 Version -00: initial submission
-

--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -236,7 +236,7 @@ The Proxy enables the UE to use a transport protocol that supports
 the different access networks even if the server does not support it (i.e., is not multipath-capable
 at transport layer).
 
-The 5G control plane provides the UE and the Proxy with ATSSS rules that specify
+The 5G control plane provides the UE and the Proxy with rules that specify
 which flows are eligible to the ATSSS service.
 
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~


### PR DESCRIPTION
Expanded on the delivery of ATSSS rules. There are two sets of rules in play - one set that determines which traffic flows are eligible for the ATSSS service, the second set are the actual ATSSS rules that govern how each flow is treated within ATSSS