### PR TITLE
Remove details about various scenarios for multiple levels of encrypt…

### DIFF
--- a/draft-quic-atsss-reqs.mkd
+++ b/draft-quic-atsss-reqs.mkd
@@ -621,11 +621,11 @@ In 3GPP architectures, a variety of encapsulations are already used to convey us
 
 More investigation is required to assess whether the ATSSS Phase 2 overhead is an issue. Solutions to optimize that overhead might be considered, if needed. 
 
-## Multiple/Redundant Encryptions
+## Multiple Encryptions
 
-QUIC data that matches an ATSSS rule will be subject to two encryptions (i.e., the one required with the remote peer and the one used to steer data via an ATSSS UPF) when forwarded via a 3GPP network access. Three encryptions will be imposed on the same data when forwarded over a non-3GPP network access (see {{sec-overhead}}). Some of these encryptions are redundant (e.g., ATSSS encryption vs. IP Encapsulating Security Payload (ESP)).
+QUIC data that matches an ATSSS rule will be subject to multiple instances of encryptions. Some of these encryptions are redundant (e.g., ATSSS encryption vs. IP Encapsulating Security Payload (ESP)).
 
-Such multiple encryptions may have performance implications on the UE, in particular. Means to optimize the various redundant encryptions are for further investigation. 
+Such multiple encryptions will have performance implications on the UE, in particular. Means to optimize the various redundant encryptions are for further investigation in 3GPP. 
 
 # Terms used in this document
 


### PR DESCRIPTION
…ion.

The less we tell IETF people about 3GPP architecture, the better :-)

More seriously, the fewer arguments we have with IETF people about whether levels of encryption are "redundant", the better. Have you met the IETF security community?